### PR TITLE
Update the imagePullPolicy to the correct value in configuration

### DIFF
--- a/manifests/myapp/templates/greeting-deployment.yaml
+++ b/manifests/myapp/templates/greeting-deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: greeting
         image: {{ .Values.greeting.image }}:{{ .Values.image.tag }}
-        imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
           name: "http"


### PR DESCRIPTION
- values.yaml has declared the pullPolicy property
- this value should be referred from the deployment as pullPolicy rather than imagePullPolicy

In [values.yaml](https://github.com/aws-samples/kubernetes-for-java-developers/blob/master/manifests/myapp/values.yaml): **pullPolicy**

```
...
image:
  tag: latest
  pullPolicy: IfNotPresent

service:
  type: LoadBalancer
  externalPort: 80
  internalPort: 8080
  externalDebugPort: 5005
  internalDebugPort: 5005
...
```

In [greeting-deployment.yaml](https://github.com/aws-samples/kubernetes-for-java-developers/blob/master/manifests/myapp/templates/greeting-deployment.yaml): **imagePullPolicy**

```
...
spec:
      containers:
      - name: greeting
        image: {{ .Values.greeting.image }}:{{ .Values.image.tag }}
        imagePullPolicy: {{ .Values.image.imagePullPolicy }}
...
```

I have changed the property in `greeting-deployment` to:

`imagePullPolicy: {{ .Values.image.pullPolicy }}`

to correspond to the property declared in `values`.